### PR TITLE
Test/cli functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+*.egg-info/
+dist/
+build/
 
 # IDE
 .vscode/

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+from rcpack import cli
+from datetime import datetime, timedelta
+import io
+import sys
+
+
+def test_log_verbose_when_enabled():
+    captured_output = io.StringIO()
+    original_stderr = sys.stderr
+    sys.stderr = captured_output
+    
+    try:
+        # log_verbose should print to stderr when verbose=True
+        cli.log_verbose("test message", verbose=True)
+        output = captured_output.getvalue()
+        assert "test message" in output
+    finally:
+        sys.stderr = original_stderr
+
+
+def test_log_verbose_when_disabled():
+    captured_output = io.StringIO()
+    original_stderr = sys.stderr
+    sys.stderr = captured_output
+    
+    try:
+        # log_verbose should NOT print when verbose=False
+        cli.log_verbose("test message", verbose=False)
+        output = captured_output.getvalue()
+        assert output == ""
+    finally:
+        sys.stderr = original_stderr
+
+
+def test_human_readable_age_just_now():
+    recent_time = datetime.now() - timedelta(seconds=30)
+    assert cli.human_readable_age(recent_time) == "just now"
+
+
+def test_human_readable_age_minutes():
+    minutes_ago = datetime.now() - timedelta(minutes=5)
+    result = cli.human_readable_age(minutes_ago)
+    assert "minute" in result
+    assert "5" in result
+
+
+def test_human_readable_age_hours():
+    hours_ago = datetime.now() - timedelta(hours=3)
+    result = cli.human_readable_age(hours_ago)
+    assert "hour" in result
+    assert "3" in result
+
+
+def test_human_readable_age_days():
+    days_ago = datetime.now() - timedelta(days=2)
+    result = cli.human_readable_age(days_ago)
+    assert "day" in result
+    assert "2" in result
+
+
+def test_human_readable_age_singular_day():
+    one_day_ago = datetime.now() - timedelta(days=1)
+    result = cli.human_readable_age(one_day_ago)
+    assert result == "1 day ago"
+
+
+def test_human_readable_age_singular_hour():
+    one_hour_ago = datetime.now() - timedelta(hours=1, minutes=0)
+    result = cli.human_readable_age(one_hour_ago)
+    assert result == "1 hour ago"


### PR DESCRIPTION
I have added test coverage for two helper functions in the CLI module that were not tested.

I have added tests for the `log_verbose` function, which handles printing debug messages when the verbose flag is enabled. Also made sure that the messages appear in staderr when verbose mode is on, and stay silent when it's off. Along with that, I also added tests for the `human_readable_age` function, which coverts timestamps into human friendly formats.

Please review and let me know if any changes required.